### PR TITLE
[refactor] Chip 아이콘 String -> Image

### DIFF
--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/component/chip/DateRoadChip.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/component/chip/DateRoadChip.kt
@@ -24,7 +24,7 @@ fun DateRoadChip(
             .clip(RoundedCornerShape(chipType.cornerRadius))
             .background(color = if (isSelected) chipType.selectedBackgroundColor else chipType.unselectedBackgroundColor)
             .noRippleClickable {
-                onSelectedChange(!isSelected)
+                onSelectedChange(isSelected)
             }
             .padding(horizontal = chipType.horizontalPadding, vertical = chipType.verticalPadding),
         contentAlignment = Alignment.Center

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/component/chip/DateRoadChip.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/component/chip/DateRoadChip.kt
@@ -14,7 +14,7 @@ import org.sopt.dateroad.presentation.util.modifier.noRippleClickable
 @Composable
 fun DateRoadChip(
     modifier: Modifier = Modifier,
-    chipType: ChipType = ChipType.ENROLL_COURSE,
+    chipType: ChipType,
     isSelected: Boolean = false,
     onSelectedChange: (Boolean) -> Unit = {},
     content: @Composable (Boolean) -> Unit
@@ -24,7 +24,7 @@ fun DateRoadChip(
             .clip(RoundedCornerShape(chipType.cornerRadius))
             .background(color = if (isSelected) chipType.selectedBackgroundColor else chipType.unselectedBackgroundColor)
             .noRippleClickable {
-                onSelectedChange(isSelected)
+                onSelectedChange(!isSelected)
             }
             .padding(horizontal = chipType.horizontalPadding, vertical = chipType.verticalPadding),
         contentAlignment = Alignment.Center

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/component/chip/DateRoadImageChip.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/component/chip/DateRoadImageChip.kt
@@ -37,7 +37,7 @@ fun DateRoadImageChip(
         ) {
             Image(
                 painter = painterResource(id = imageRes),
-                contentDescription = null,
+                contentDescription = null
             )
             Spacer(modifier = Modifier.size(2.dp))
             Text(

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/component/chip/DateRoadImageChip.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/component/chip/DateRoadImageChip.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import org.sopt.dateroad.presentation.type.ChipType
 import org.sopt.dateroad.presentation.type.DateTagType
@@ -23,6 +24,7 @@ fun DateRoadImageChip(
     @StringRes textId: Int,
     @DrawableRes imageRes: Int,
     chipType: ChipType,
+    spaceValue: Dp = 2.dp,
     isSelected: Boolean = false,
     onSelectedChange: (Boolean) -> Unit = {}
 ) {
@@ -39,7 +41,7 @@ fun DateRoadImageChip(
                 painter = painterResource(id = imageRes),
                 contentDescription = null
             )
-            Spacer(modifier = Modifier.size(2.dp))
+            Spacer(modifier = Modifier.size(spaceValue))
             Text(
                 text = stringResource(id = textId),
                 style = chipType.textStyle,

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/component/chip/DateRoadImageChip.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/component/chip/DateRoadImageChip.kt
@@ -1,0 +1,61 @@
+package org.sopt.dateroad.presentation.ui.component.chip
+
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.sopt.dateroad.presentation.type.ChipType
+import org.sopt.dateroad.presentation.type.DateTagType
+
+@Composable
+fun DateRoadImageChip(
+    modifier: Modifier = Modifier,
+    @StringRes textId: Int,
+    @DrawableRes imageRes: Int,
+    chipType: ChipType,
+    isSelected: Boolean = false,
+    onSelectedChange: (Boolean) -> Unit = {}
+) {
+    DateRoadChip(
+        modifier = modifier,
+        chipType = chipType,
+        isSelected = isSelected,
+        onSelectedChange = onSelectedChange
+    ) { selected ->
+        Row(
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Image(
+                painter = painterResource(id = imageRes),
+                contentDescription = null,
+                modifier = Modifier.size(24.dp)
+            )
+            Spacer(modifier = Modifier.size(8.dp))
+            Text(
+                text = stringResource(id = textId),
+                style = chipType.textStyle,
+                color = if (selected) chipType.selectedTextColor else chipType.unselectedTextColor
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun DateRoadImageChipPreview() {
+    DateRoadImageChip(
+        textId = DateTagType.EXHIBITION_POP_UP.titleRes,
+        imageRes = DateTagType.EXHIBITION_POP_UP.imageRes,
+        chipType = ChipType.MY_PROFILE
+    )
+}

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/component/chip/DateRoadImageChip.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/component/chip/DateRoadImageChip.kt
@@ -38,9 +38,8 @@ fun DateRoadImageChip(
             Image(
                 painter = painterResource(id = imageRes),
                 contentDescription = null,
-                modifier = Modifier.size(24.dp)
             )
-            Spacer(modifier = Modifier.size(8.dp))
+            Spacer(modifier = Modifier.size(2.dp))
             Text(
                 text = stringResource(id = textId),
                 style = chipType.textStyle,

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/component/chip/DateRoadTextChip.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/component/chip/DateRoadTextChip.kt
@@ -38,7 +38,7 @@ fun DateRoadTextChip(
 
 @Preview
 @Composable
-fun DateRoadChipPreview() {
+fun DateRoadTextChipPreview() {
     Column {
         DateRoadTextChip(textId = R.string.money_tag_less_than_100000, chipType = ChipType.MONEY)
         Spacer(modifier = Modifier.height(10.dp))


### PR DESCRIPTION
## Related issue 🛠
- closed #45 

## Work Description ✏️
- 원래 String 안에 포함되어 있던 아이콘을 디자인 변경에 따른 Image로 적용

## Screenshot 📸
<img width="271" alt="image" src="https://github.com/TeamDATEROAD/DATEROAD-ANDROID/assets/122257945/39aa9837-4891-4318-8f5f-d28fe75d0cb7">

## Uncompleted Tasks 😅
- 없습니다!

## To Reviewers 📢