### PR TITLE
[feat] Advertisement 컴포넌트 구현

### DIFF
--- a/app/src/main/java/org/sopt/dateroad/domain/model/Advertisement.kt
+++ b/app/src/main/java/org/sopt/dateroad/domain/model/Advertisement.kt
@@ -1,0 +1,8 @@
+package org.sopt.dateroad.domain.model
+
+data class Advertisement(
+    val advertismentId: Int,
+    val imageUrl: String,
+    val title: String,
+    val tag: String
+)

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/component/item/DateRoadAdvertisement.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/component/item/DateRoadAdvertisement.kt
@@ -1,0 +1,76 @@
+package org.sopt.dateroad.presentation.ui.component.item
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import org.sopt.dateroad.domain.model.Advertisement
+import org.sopt.dateroad.presentation.type.TagType
+import org.sopt.dateroad.presentation.ui.component.tag.DateRoadTextTag
+import org.sopt.dateroad.ui.theme.DateRoadTheme
+
+@Composable
+fun DateRoadAdvertisement(
+    advertisement: Advertisement
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(132.dp)
+            .clip(RoundedCornerShape(14.dp))
+    ) {
+        AsyncImage(
+            model = ImageRequest.Builder(context = LocalContext.current)
+                .data(advertisement.imageUrl)
+                .crossfade(true)
+                .build(),
+            placeholder = null,
+            contentDescription = null
+        )
+        Column(
+            modifier = Modifier.padding(13.dp)
+        ) {
+            DateRoadTextTag(
+                textContent = advertisement.tag,
+                tagContentType = TagType.ADVERTISEMENT_TITLE
+            )
+            Spacer(modifier = Modifier.size(10.dp))
+            Text(
+                text = advertisement.title,
+                style = DateRoadTheme.typography.bodyBold15,
+                color = DateRoadTheme.colors.gray400,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun DateRoadAdvertisementPreview() {
+    Column {
+        DateRoadAdvertisement(
+            advertisement = Advertisement(
+                advertismentId = 0,
+                imageUrl = "www.naver.jpg",
+                title = "관리자 아카이빙 게시물 이름",
+                tag = "에디터 픽"
+            )
+        )
+    }
+}

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/component/item/HomeAdvertisement.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/component/item/HomeAdvertisement.kt
@@ -3,8 +3,8 @@ package org.sopt.dateroad.presentation.ui.component.item
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -21,17 +21,20 @@ import coil.request.ImageRequest
 import org.sopt.dateroad.domain.model.Advertisement
 import org.sopt.dateroad.presentation.type.TagType
 import org.sopt.dateroad.presentation.ui.component.tag.DateRoadTextTag
+import org.sopt.dateroad.presentation.util.modifier.noRippleClickable
 import org.sopt.dateroad.ui.theme.DateRoadTheme
 
 @Composable
-fun DateRoadAdvertisement(
-    advertisement: Advertisement
+fun HomeAdvertisement(
+    advertisement: Advertisement,
+    onClick: (Int) -> Unit = {}
 ) {
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .height(132.dp)
             .clip(RoundedCornerShape(14.dp))
+            .aspectRatio(328f / 132f)
+            .noRippleClickable(onClick = { onClick(advertisement.advertismentId) })
     ) {
         AsyncImage(
             model = ImageRequest.Builder(context = LocalContext.current)
@@ -62,9 +65,9 @@ fun DateRoadAdvertisement(
 
 @Preview
 @Composable
-fun DateRoadAdvertisementPreview() {
+fun HomeAdvertisementPreview() {
     Column {
-        DateRoadAdvertisement(
+        HomeAdvertisement(
             advertisement = Advertisement(
                 advertismentId = 0,
                 imageUrl = "www.naver.jpg",


### PR DESCRIPTION
## Related issue 🛠
- closed #50 

## Work Description ✏️
- Advertisement 컴포넌트 구현

## Screenshot 📸
<img src="https://github.com/TeamDATEROAD/DATEROAD-ANDROID/assets/95455569/9883bef0-506c-454f-adb9-18e2d2cddfb6" width="360"/>

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢