### PR TITLE
[fix] 코스 둘러보기 (Look) 뷰 지역 버튼 디자인 변경

### DIFF
--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/component/button/DateRoadAreaButton.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/component/button/DateRoadAreaButton.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -18,6 +19,7 @@ import org.sopt.dateroad.ui.theme.DateRoadTheme
 @Composable
 fun DateRoadAreaButton(
     modifier: Modifier = Modifier,
+    isSelected: Boolean,
     textContent: String,
     onClick: () -> Unit = {}
 ) {
@@ -25,6 +27,8 @@ fun DateRoadAreaButton(
         modifier = modifier
             .fillMaxWidth(),
         backgroundColor = DateRoadTheme.colors.gray100,
+        borderColor = if (isSelected) DateRoadTheme.colors.deepPurple else Color.Unspecified,
+        borderWidth = 1.dp,
         cornerRadius = 10.dp,
         paddingVertical = 6.dp,
         paddingHorizontal = 12.dp,
@@ -35,11 +39,11 @@ fun DateRoadAreaButton(
         ) {
             Text(
                 text = textContent,
-                color = DateRoadTheme.colors.gray400,
+                color = if (isSelected) DateRoadTheme.colors.deepPurple else DateRoadTheme.colors.gray400,
                 style = DateRoadTheme.typography.bodyMed13
             )
             Spacer(modifier = Modifier.weight(1f))
-            Icon(painter = painterResource(id = R.drawable.ic_area_dropdown), contentDescription = null, tint = DateRoadTheme.colors.gray400)
+            Icon(painter = painterResource(id = R.drawable.ic_area_dropdown), contentDescription = null, tint = if (isSelected) DateRoadTheme.colors.deepPurple else DateRoadTheme.colors.gray400)
         }
     }
 }
@@ -49,7 +53,8 @@ fun DateRoadAreaButton(
 fun DateRoadAreaButtonPreview() {
     DATEROADTheme {
         DateRoadAreaButton(
-            textContent = "건대/성수/왕십리"
+            textContent = "건대/성수/왕십리",
+            isSelected = true
         )
     }
 }

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/look/LookScreen.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/look/LookScreen.kt
@@ -116,6 +116,7 @@ fun LookScreen(
             Spacer(modifier = Modifier.width(16.dp))
             DateRoadAreaButton(
                 modifier = Modifier.weight(1f),
+                isSelected = lookUiState.area != null,
                 textContent = stringResource(
                     id = when (lookUiState.area) {
                         is SeoulAreaType -> lookUiState.area.nameRes


### PR DESCRIPTION
## Related issue 🛠
- closed #76 

## Work Description ✏️
- 코스 둘러보기 (Look) 뷰에 있는 지역 버튼의 디자인을 변경하였습니다.

## Screenshot 📸

https://github.com/TeamDATEROAD/DATEROAD-ANDROID/assets/103172971/0f1a920c-80ef-4f01-8d9b-ef653bb3e17d


## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
디자인 반영 끝!