### PR TITLE
[chore] 지역 관련 API 통신 Enum -> 한글 변경

### DIFF
--- a/app/src/main/java/org/sopt/dateroad/data/mapper/toEntity/AreaMapper.kt
+++ b/app/src/main/java/org/sopt/dateroad/data/mapper/toEntity/AreaMapper.kt
@@ -20,13 +20,6 @@ fun Any?.toAreaTitle(): String = when (this) {
     else -> ""
 }
 
-fun Any?.toAreaName(): String = when (this) {
-    is SeoulAreaType -> this.name
-    is GyeonggiAreaType -> this.name
-    is IncheonAreaType -> this.name
-    else -> ""
-}
-
 fun String.toAreaType(): Any? =
     when {
         this.toSeoulAreaTitle().isNotEmpty() -> this.toSeoulAreaType()

--- a/app/src/main/java/org/sopt/dateroad/data/mapper/todata/EnrollMapper.kt
+++ b/app/src/main/java/org/sopt/dateroad/data/mapper/todata/EnrollMapper.kt
@@ -2,7 +2,7 @@ package org.sopt.dateroad.data.mapper.todata
 
 import org.sopt.dateroad.data.dataremote.model.request.RequestCourseDto
 import org.sopt.dateroad.data.dataremote.model.request.RequestTimelineDto
-import org.sopt.dateroad.data.mapper.toEntity.toAreaName
+import org.sopt.dateroad.data.mapper.toEntity.toAreaTitle
 import org.sopt.dateroad.domain.model.Enroll
 
 fun Enroll.toTimelineData(): RequestTimelineDto = RequestTimelineDto(
@@ -10,8 +10,8 @@ fun Enroll.toTimelineData(): RequestTimelineDto = RequestTimelineDto(
     date = this.date,
     startAt = this.startAt,
     tags = this.tags.map { tag -> tag.toData() },
-    country = this.country?.name.orEmpty(),
-    city = this.city.toAreaName(),
+    country = this.country?.title.orEmpty(),
+    city = this.city.toAreaTitle(),
     places = places.mapIndexed { index, place -> place.toData(sequence = index) }
 )
 
@@ -19,8 +19,8 @@ fun Enroll.toCourseData(): RequestCourseDto = RequestCourseDto(
     title = this.title,
     date = this.date,
     startAt = this.startAt,
-    country = country?.name.orEmpty(),
-    city = this.city.toAreaName(),
+    country = country?.title.orEmpty(),
+    city = this.city.toAreaTitle(),
     description = this.description,
     cost = this.cost.toInt()
 )

--- a/app/src/main/java/org/sopt/dateroad/data/repositoryimpl/CourseRepositoryImpl.kt
+++ b/app/src/main/java/org/sopt/dateroad/data/repositoryimpl/CourseRepositoryImpl.kt
@@ -2,6 +2,7 @@ package org.sopt.dateroad.data.repositoryimpl
 
 import android.content.ContentResolver
 import android.net.Uri
+import javax.inject.Inject
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
@@ -21,7 +22,6 @@ import org.sopt.dateroad.domain.type.MoneyTagType
 import org.sopt.dateroad.domain.type.RegionType
 import org.sopt.dateroad.domain.type.SeoulAreaType
 import org.sopt.dateroad.domain.type.SortByType
-import javax.inject.Inject
 
 class CourseRepositoryImpl @Inject constructor(
     private val contentResolver: ContentResolver,

--- a/app/src/main/java/org/sopt/dateroad/data/repositoryimpl/CourseRepositoryImpl.kt
+++ b/app/src/main/java/org/sopt/dateroad/data/repositoryimpl/CourseRepositoryImpl.kt
@@ -2,7 +2,6 @@ package org.sopt.dateroad.data.repositoryimpl
 
 import android.content.ContentResolver
 import android.net.Uri
-import javax.inject.Inject
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
@@ -22,6 +21,7 @@ import org.sopt.dateroad.domain.type.MoneyTagType
 import org.sopt.dateroad.domain.type.RegionType
 import org.sopt.dateroad.domain.type.SeoulAreaType
 import org.sopt.dateroad.domain.type.SortByType
+import javax.inject.Inject
 
 class CourseRepositoryImpl @Inject constructor(
     private val contentResolver: ContentResolver,
@@ -41,12 +41,12 @@ class CourseRepositoryImpl @Inject constructor(
 
     override suspend fun getFilteredCourses(country: RegionType?, city: Any?, cost: MoneyTagType?): Result<List<Course>> = runCatching {
         courseRemoteDataSource.getFilteredCourses(
-            country = country?.name,
+            country = country?.title,
             city = city?.let {
                 when (it) {
-                    is SeoulAreaType -> it.name
-                    is GyeonggiAreaType -> it.name
-                    is IncheonAreaType -> it.name
+                    is SeoulAreaType -> it.title
+                    is GyeonggiAreaType -> it.title
+                    is IncheonAreaType -> it.title
                     else -> null
                 }
             },

--- a/app/src/main/java/org/sopt/dateroad/domain/type/SeoulAreaType.kt
+++ b/app/src/main/java/org/sopt/dateroad/domain/type/SeoulAreaType.kt
@@ -14,11 +14,17 @@ enum class SeoulAreaType(
     JAMSIL_SONGPA_GANGDONG(
         title = Seoul.JAMSIL_SONGPA_GANGDONG
     ),
-    KONDAE_SUNGSOO_WANGSIMNI(
-        title = Seoul.KONDAE_SUNGSOO_WANGSIMNI
+    KONDAE_SEONGSU_SEONGDONG(
+        title = Seoul.KONDAE_SEONGSU_SEONGDONG
+    ),
+    GWANGIN_JUNGBANG(
+        title = Seoul.GWANGIN_JUNGBANG
     ),
     JONGNO_JUNGRO(
         title = Seoul.JONGNO_JUNGRO
+    ),
+    EUNPYEONG_SEODAEMUN(
+      title = Seoul.EUNPYEONG_SEODAEMUN
     ),
     HONGDAE_HAPJEONG_MAPO(
         title = Seoul.HONGDAE_HAPJEONG_MAPO
@@ -29,14 +35,17 @@ enum class SeoulAreaType(
     YONGSAN_ITAEWON_HANNAM(
         title = Seoul.YONGSAN_ITAEWON_HANNAM
     ),
-    YANGCHEON_GANGSEO(
-        title = Seoul.YANGCHEON_GANGSEO
+    YANGCHEON_GANGSEO_GURO(
+        title = Seoul.YANGCHEON_GANGSEO_GURO
     ),
-    SEONGBUK_NOWON_JUNGBANG(
-        title = Seoul.SEONGBUK_NOWON_JUNGBANG
+    DONGDAEMUN_SEONGBUK(
+        title = Seoul.DONGDAEMUN_SEONGBUK
     ),
-    GURO_GWANAK_DONGJAK(
-        title = Seoul.GURO_GWANAK_DONGJAK
+    NOWON_DOBONG_GANGBUK(
+        title = Seoul.NOWON_DOBONG_GANGBUK
+    ),
+    GWANAK_DONGJAK_GEUMCHEON(
+        title = Seoul.GWANAK_DONGJAK_GEUMCHEON
     );
 
     companion object {

--- a/app/src/main/java/org/sopt/dateroad/domain/type/SeoulAreaType.kt
+++ b/app/src/main/java/org/sopt/dateroad/domain/type/SeoulAreaType.kt
@@ -24,7 +24,7 @@ enum class SeoulAreaType(
         title = Seoul.JONGNO_JUNGRO
     ),
     EUNPYEONG_SEODAEMUN(
-      title = Seoul.EUNPYEONG_SEODAEMUN
+        title = Seoul.EUNPYEONG_SEODAEMUN
     ),
     HONGDAE_HAPJEONG_MAPO(
         title = Seoul.HONGDAE_HAPJEONG_MAPO

--- a/app/src/main/java/org/sopt/dateroad/domain/util/Constraints.kt
+++ b/app/src/main/java/org/sopt/dateroad/domain/util/Constraints.kt
@@ -17,14 +17,17 @@ object Seoul {
     const val SEOUL_ENTIRE = "서울 전체"
     const val GANGNAM_SEOCHO = "강남/서초"
     const val JAMSIL_SONGPA_GANGDONG = "잠실/송파/강동"
-    const val KONDAE_SUNGSOO_WANGSIMNI = "건대/성수/왕십리"
+    const val KONDAE_SEONGSU_SEONGDONG = "건대/성수/성동"
+    const val GWANGIN_JUNGBANG = "광진/중랑"
     const val JONGNO_JUNGRO = "종로/중구"
+    const val EUNPYEONG_SEODAEMUN = "은평/서대문"
     const val HONGDAE_HAPJEONG_MAPO = "홍대/합정/마포"
     const val YEONGDEUNGPO_YEOUIDO = "영등포/여의도"
     const val YONGSAN_ITAEWON_HANNAM = "용산/이태원/한남"
-    const val YANGCHEON_GANGSEO = "양천/강서"
-    const val SEONGBUK_NOWON_JUNGBANG = "성북/노원/중랑"
-    const val GURO_GWANAK_DONGJAK = "구로/관악/동작"
+    const val YANGCHEON_GANGSEO_GURO = "양천/강서/구로"
+    const val DONGDAEMUN_SEONGBUK = "동대문/성북"
+    const val NOWON_DOBONG_GANGBUK = "노원/도봉/강북"
+    const val GWANAK_DONGJAK_GEUMCHEON = "관악/동작/금천"
 }
 
 object Gyeonggi {


### PR DESCRIPTION
## Related issue 🛠
- closed #195 

## Work Description ✏️
- 변경된 지역 필터 값을 반영했어요.
- 지역 관련 API 통신에서 Enum이 사용되는 부분을 한글로 변경하였어요.
    - 데이트 코스 전체 조회 API
    -  데이트 코스 등록 API
    -  데이트 일정 등록 API 

## Screenshot 📸
[코스 둘러보기]

https://github.com/user-attachments/assets/c20d713e-d833-40e0-8294-74b2ce216e11

[데이트 코스 등록]

https://github.com/user-attachments/assets/289dec11-4cd6-4231-8126-77dff8078e6c

[데이트 일정 등록]

https://github.com/user-attachments/assets/e5b54a3e-49b9-45a5-9d18-070051f579db

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
- 에러 발생하는 부분 디코에 남겨두었어요 - 서버와 논의 중 (데이트 일정 등록 API (api/v1/dates)에서 변경된 지역 값으로 데이트 일정 등록 요청 시 서버 에러 발생)
- 얘들아 늦게 해서 미안해 ㅠㅠ