### PR TITLE
[chore] 자체 QA - 홈(Home) 뷰

### DIFF
--- a/app/src/main/java/org/sopt/dateroad/data/dataremote/util/Constraints.kt
+++ b/app/src/main/java/org/sopt/dateroad/data/dataremote/util/Constraints.kt
@@ -49,7 +49,7 @@ object Cost {
 }
 
 object Duration {
-    const val DURATION = " 시간"
+    const val DURATION = "시간"
 }
 
 object Like {

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/component/card/DateRoadCourseCard.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/component/card/DateRoadCourseCard.kt
@@ -30,7 +30,6 @@ import org.sopt.dateroad.presentation.type.TagType
 import org.sopt.dateroad.presentation.ui.component.tag.DateRoadImageTag
 import org.sopt.dateroad.presentation.util.modifier.noRippleClickable
 import org.sopt.dateroad.ui.theme.DateRoadTheme
-import kotlin.math.min
 
 @Composable
 fun DateRoadCourseCard(

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/component/card/DateRoadCourseCard.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/component/card/DateRoadCourseCard.kt
@@ -30,6 +30,7 @@ import org.sopt.dateroad.presentation.type.TagType
 import org.sopt.dateroad.presentation.ui.component.tag.DateRoadImageTag
 import org.sopt.dateroad.presentation.util.modifier.noRippleClickable
 import org.sopt.dateroad.ui.theme.DateRoadTheme
+import kotlin.math.min
 
 @Composable
 fun DateRoadCourseCard(
@@ -91,6 +92,7 @@ fun DateRoadCourseCard(
                 color = DateRoadTheme.colors.black,
                 modifier = Modifier
                     .fillMaxWidth(),
+                minLines = 2,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis
             )

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/component/tag/DateRoadPointTag.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/component/tag/DateRoadPointTag.kt
@@ -3,7 +3,9 @@ package org.sopt.dateroad.presentation.ui.component.tag
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
@@ -12,10 +14,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
 import org.sopt.dateroad.R
 import org.sopt.dateroad.presentation.util.modifier.noRippleClickable
 import org.sopt.dateroad.ui.theme.DATEROADTheme
@@ -25,7 +30,7 @@ import org.sopt.dateroad.ui.theme.DateRoadTheme
 fun DateRoadPointTag(
     modifier: Modifier = Modifier,
     text: String,
-    profileImage: Painter,
+    profileImage: String? = null,
     backgroundColor: Color = DateRoadTheme.colors.purple500,
     contentColor: Color = DateRoadTheme.colors.white,
     onClick: () -> Unit = {}
@@ -45,12 +50,31 @@ fun DateRoadPointTag(
             modifier = modifier
                 .padding(start = 14.dp, end = 7.dp)
         )
-        Image(
-            painter = profileImage,
-            contentDescription = null,
-            modifier = modifier
-                .clip(CircleShape)
-        )
+        if (profileImage.isNullOrEmpty()) {
+            Image(
+                modifier = Modifier
+                    .width(33.dp)
+                    .aspectRatio(1f)
+                    .clip(CircleShape),
+                painter = painterResource(id = R.drawable.img_profile_small),
+                contentDescription = null,
+                contentScale = ContentScale.Crop
+            )
+        } else {
+            AsyncImage(
+                modifier = Modifier
+                    .width(33.dp)
+                    .aspectRatio(1f)
+                    .clip(CircleShape),
+                model = ImageRequest.Builder(context = LocalContext.current)
+                    .data(profileImage)
+                    .crossfade(true)
+                    .build(),
+                placeholder = null,
+                contentDescription = null,
+                contentScale = ContentScale.Crop
+            )
+        }
     }
 }
 
@@ -60,7 +84,7 @@ fun DateRoadPointTagPreview() {
     DATEROADTheme {
         DateRoadPointTag(
             text = "5000 P",
-            profileImage = painterResource(id = R.drawable.img_top_bar_profile)
+            profileImage = null
         )
     }
 }

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/home/HomeContract.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/home/HomeContract.kt
@@ -5,6 +5,7 @@ import org.sopt.dateroad.domain.model.Course
 import org.sopt.dateroad.domain.model.NearestTimeline
 import org.sopt.dateroad.domain.model.UserPoint
 import org.sopt.dateroad.presentation.type.EnrollType
+import org.sopt.dateroad.presentation.type.TimelineType
 import org.sopt.dateroad.presentation.util.base.UiEvent
 import org.sopt.dateroad.presentation.util.base.UiSideEffect
 import org.sopt.dateroad.presentation.util.base.UiState
@@ -25,7 +26,7 @@ class HomeContract {
     sealed interface HomeSideEffect : UiSideEffect {
         data object NavigateToPointHistory : HomeSideEffect
         data object NavigateToLook : HomeSideEffect
-        data object NavigateToTimeline : HomeSideEffect
+        data class NavigateToTimelineDetail(val timelineType: TimelineType, val timelineId: Int) : HomeSideEffect
         data class NavigateToEnroll(val enrollType: EnrollType, val id: Int?) : HomeSideEffect
         data class NavigateToAdvertisementDetail(val advertisementId: Int) : HomeSideEffect
         data class NavigateToCourseDetail(val courseId: Int) : HomeSideEffect

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/home/HomeScreen.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/home/HomeScreen.kt
@@ -41,6 +41,7 @@ import org.sopt.dateroad.domain.model.NearestTimeline
 import org.sopt.dateroad.domain.type.SortByType
 import org.sopt.dateroad.presentation.type.EnrollType
 import org.sopt.dateroad.presentation.type.TagType
+import org.sopt.dateroad.presentation.type.TimelineType
 import org.sopt.dateroad.presentation.ui.component.button.DateRoadImageButton
 import org.sopt.dateroad.presentation.ui.component.button.DateRoadTextButton
 import org.sopt.dateroad.presentation.ui.component.card.DateRoadCourseCard
@@ -63,7 +64,7 @@ fun HomeRoute(
     viewModel: HomeViewModel = hiltViewModel(),
     navigateToPointHistory: () -> Unit,
     navigateToLook: () -> Unit,
-    navigateToTimeline: () -> Unit,
+    navigateToTimelineDetail: (TimelineType, Int) -> Unit,
     navigateToEnroll: (EnrollType, Int?) -> Unit,
     navigateToAdvertisementDetail: (Int) -> Unit,
     navigateToCourseDetail: (Int) -> Unit
@@ -97,7 +98,7 @@ fun HomeRoute(
                 when (homeSideEffect) {
                     is HomeContract.HomeSideEffect.NavigateToPointHistory -> navigateToPointHistory()
                     is HomeContract.HomeSideEffect.NavigateToLook -> navigateToLook()
-                    is HomeContract.HomeSideEffect.NavigateToTimeline -> navigateToTimeline()
+                    is HomeContract.HomeSideEffect.NavigateToTimelineDetail -> navigateToTimelineDetail(homeSideEffect.timelineType, homeSideEffect.timelineId)
                     is HomeContract.HomeSideEffect.NavigateToEnroll -> navigateToEnroll(homeSideEffect.enrollType, homeSideEffect.id)
                     is HomeContract.HomeSideEffect.NavigateToAdvertisementDetail -> navigateToAdvertisementDetail(homeSideEffect.advertisementId)
                     is HomeContract.HomeSideEffect.NavigateToCourseDetail -> navigateToCourseDetail(homeSideEffect.courseId)
@@ -118,7 +119,7 @@ fun HomeRoute(
                 navigateToEnroll = { viewModel.setSideEffect(HomeContract.HomeSideEffect.NavigateToEnroll(EnrollType.TIMELINE, null)) },
                 navigateToPointHistory = { viewModel.setSideEffect(HomeContract.HomeSideEffect.NavigateToPointHistory) },
                 navigateToLook = { viewModel.setSideEffect(HomeContract.HomeSideEffect.NavigateToLook) },
-                navigateToTimeline = { viewModel.setSideEffect(HomeContract.HomeSideEffect.NavigateToTimeline) },
+                navigateToTimelineDetail = { timelineType, timelineId -> viewModel.setSideEffect(HomeContract.HomeSideEffect.NavigateToTimelineDetail(timelineType = timelineType, timelineId = timelineId)) },
                 onFabClick = { viewModel.setSideEffect(HomeContract.HomeSideEffect.NavigateToEnroll(EnrollType.COURSE, null)) },
                 navigateToAdvertisementDetail = { advertisementId: Int -> viewModel.setSideEffect(HomeContract.HomeSideEffect.NavigateToAdvertisementDetail(advertisementId = advertisementId)) },
                 navigateToCourseDetail = { courseId: Int -> viewModel.setSideEffect(HomeContract.HomeSideEffect.NavigateToCourseDetail(courseId = courseId)) }
@@ -138,7 +139,7 @@ fun HomeScreen(
     navigateToEnroll: () -> Unit,
     navigateToPointHistory: () -> Unit,
     navigateToLook: () -> Unit,
-    navigateToTimeline: () -> Unit,
+    navigateToTimelineDetail: (TimelineType, Int) -> Unit,
     navigateToAdvertisementDetail: (Int) -> Unit,
     navigateToCourseDetail: (Int) -> Unit,
     onFabClick: () -> Unit
@@ -160,10 +161,12 @@ fun HomeScreen(
         ) {
             HomeTimeLineCard(
                 nearestTimeline = uiState.nearestTimeline,
-                onClick = if (uiState.nearestTimeline == NearestTimeline()) {
-                    navigateToEnroll
-                } else {
-                    navigateToTimeline
+                onClick = {
+                    if (uiState.nearestTimeline == NearestTimeline()) {
+                        navigateToEnroll()
+                    } else {
+                        navigateToTimelineDetail(TimelineType.PINK, uiState.nearestTimeline.timelineId)
+                    }
                 }
             )
         }

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/home/HomeScreen.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/home/HomeScreen.kt
@@ -214,7 +214,7 @@ fun HomeScreen(
                     )
                 }
                 Spacer(modifier = Modifier.height(13.dp))
-                Row(modifier = Modifier.padding(horizontal = 16.dp)) {
+                Row(modifier = Modifier.padding(start = 16.dp)) {
                     LazyRow(
                         horizontalArrangement = Arrangement.spacedBy(16.dp)
                     ) {

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/home/HomeScreen.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/home/HomeScreen.kt
@@ -152,7 +152,7 @@ fun HomeScreen(
     ) {
         DateRoadHomeTopBar(
             title = uiState.userPoint.point,
-            profileImage = uiState.profileImageUrl,
+            profileImage = uiState.userPoint.imageUrl,
             onClick = navigateToPointHistory
         )
         Row(

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/home/component/HomeAdvertisement.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/home/component/HomeAdvertisement.kt
@@ -2,7 +2,6 @@ package org.sopt.dateroad.presentation.ui.home.component
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/home/component/HomeAdvertisement.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/home/component/HomeAdvertisement.kt
@@ -28,7 +28,6 @@ fun HomeAdvertisement(
             .padding(start = 16.dp, end = 16.dp)
             .fillMaxWidth()
             .clip(RoundedCornerShape(14.dp))
-            .aspectRatio(328f / 132f)
             .noRippleClickable(onClick = { onClick(advertisement.advertisementId) })
     ) {
         AsyncImage(

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/home/component/HomeTopBar.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/home/component/HomeTopBar.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import coil.compose.rememberAsyncImagePainter
 import org.sopt.dateroad.R
 import org.sopt.dateroad.presentation.ui.component.tag.DateRoadPointTag
 import org.sopt.dateroad.ui.theme.DateRoadTheme
@@ -40,11 +39,7 @@ fun DateRoadHomeTopBar(
         Spacer(modifier = Modifier.weight(1f))
         DateRoadPointTag(
             text = title,
-            profileImage = if (profileImage != null) {
-                rememberAsyncImagePainter(profileImage)
-            } else {
-                painterResource(id = R.drawable.img_profile_small)
-            },
+            profileImage = profileImage,
             onClick = onClick
         )
     }

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/home/navigation/HomeNavigation.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/home/navigation/HomeNavigation.kt
@@ -7,6 +7,7 @@ import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import org.sopt.dateroad.presentation.model.MainNavigationBarRoute
 import org.sopt.dateroad.presentation.type.EnrollType
+import org.sopt.dateroad.presentation.type.TimelineType
 import org.sopt.dateroad.presentation.ui.home.HomeRoute
 
 fun NavController.navigationHome(navOptions: NavOptions) {
@@ -20,7 +21,7 @@ fun NavGraphBuilder.homeNavGraph(
     padding: PaddingValues,
     navigateToPointHistory: () -> Unit,
     navigateToLook: () -> Unit,
-    navigateToTimeline: () -> Unit,
+    navigateToTimelineDetail: (TimelineType, Int) -> Unit,
     navigateToEnroll: (EnrollType, Int?) -> Unit,
     navigateToAdvertisement: (Int) -> Unit,
     navigateToCourseDetail: (Int) -> Unit
@@ -30,7 +31,7 @@ fun NavGraphBuilder.homeNavGraph(
             padding = padding,
             navigateToPointHistory = navigateToPointHistory,
             navigateToLook = navigateToLook,
-            navigateToTimeline = navigateToTimeline,
+            navigateToTimelineDetail = navigateToTimelineDetail,
             navigateToEnroll = navigateToEnroll,
             navigateToAdvertisementDetail = navigateToAdvertisement,
             navigateToCourseDetail = navigateToCourseDetail

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/navigator/component/MainNavHost.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/navigator/component/MainNavHost.kt
@@ -62,7 +62,7 @@ fun MainNavHost(
                 padding = padding,
                 navigateToPointHistory = navigator::navigateToPointHistory,
                 navigateToLook = navigator::navigateToLook,
-                navigateToTimeline = navigator::navigateTimeline,
+                navigateToTimelineDetail = navigator::navigateToTimelineDetail,
                 navigateToEnroll = navigator::navigateToEnroll,
                 navigateToAdvertisement = navigator::navigateToAdvertisement,
                 navigateToCourseDetail = navigator::navigateToCourseDetail


### PR DESCRIPTION
## Related issue 🛠
- closed #217 

## Work Description ✏️
- 프로필 기본이미지 -> 실제 프로필 이미지
- 다가오는 데이트 > 클릭 시 해당 데이트 상세 페이지로 이동 
- 광고 배너 비율 조정
- HOT 데이트 코스 오른쪽 마진 없도록 설정
- 0 시간 (전체적으로) 공백 삭제 -> 0시간
- 데이트 코스 카드 minLines속성 추가 (2줄)

## Screenshot 📸
실제 프로필 이미지

<img width="327" alt="image" src="https://github.com/user-attachments/assets/f9c85f00-79fc-406f-b1ab-24bd7fa36862">

데이트 상세 페이지로 이동

https://github.com/user-attachments/assets/65c27c9c-5d28-4159-a484-75d5352949a1

광고 배너 비율

<img width="343" alt="image" src="https://github.com/user-attachments/assets/46a53e81-7cfd-47ef-9361-aedbdad38021">

Hot 데이트 코스 오른쪽 패딩 제거

<img width="388" alt="image" src="https://github.com/user-attachments/assets/b96a20d4-0a84-43f2-b7a9-fdc5d9a514fb">

시간 숫자, 텍스트 사이 공백 제거

<img width="225" alt="image" src="https://github.com/user-attachments/assets/1a3f5026-4a74-4cce-b698-eec8927de0eb">

데이트 카드 minLines 속성 추가 및 2로 설정

<img width="317" alt="image" src="https://github.com/user-attachments/assets/b9b5f644-260c-46dd-a20e-e4f33de9a823">


## Uncompleted Tasks 😅
- [x] 스샷

## To Reviewers 📢
와 6시 반 전에 끝냈네 그래도 힣