### PR TITLE
[fix] 버튼 중복 클릭 문제 해결

### DIFF
--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/component/button/DateRoadButton.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/component/button/DateRoadButton.kt
@@ -23,14 +23,14 @@ fun DateRoadButton(
     cornerRadius: Dp = 0.dp,
     paddingHorizontal: Dp = 0.dp,
     paddingVertical: Dp = 0.dp,
-    onClick: () -> Unit,
+    onClick: suspend () -> Unit,
     content: @Composable () -> Unit
 ) {
     Box(
         modifier = modifier
             .clip(RoundedCornerShape(cornerRadius))
             .background(color = backgroundColor)
-            .noRippleDebounceClickable(onClick = onClick)
+            .noRippleDebounceClickable (onClick = onClick)
             .border(width = borderWidth, color = borderColor, shape = RoundedCornerShape(cornerRadius))
             .padding(horizontal = paddingHorizontal, vertical = paddingVertical),
         contentAlignment = Alignment.Center

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/component/button/DateRoadButton.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/component/button/DateRoadButton.kt
@@ -30,7 +30,7 @@ fun DateRoadButton(
         modifier = modifier
             .clip(RoundedCornerShape(cornerRadius))
             .background(color = backgroundColor)
-            .noRippleDebounceClickable (onClick = onClick)
+            .noRippleDebounceClickable(onClick = onClick)
             .border(width = borderWidth, color = borderColor, shape = RoundedCornerShape(cornerRadius))
             .padding(horizontal = paddingHorizontal, vertical = paddingVertical),
         contentAlignment = Alignment.Center

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/enroll/EnrollScreen.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/enroll/EnrollScreen.kt
@@ -28,6 +28,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import org.sopt.dateroad.R
 import org.sopt.dateroad.domain.model.Place
 import org.sopt.dateroad.domain.type.RegionType
@@ -56,8 +58,6 @@ import org.sopt.dateroad.presentation.util.TimePicker
 import org.sopt.dateroad.presentation.util.view.LoadState
 import org.sopt.dateroad.ui.theme.DATEROADTheme
 import org.sopt.dateroad.ui.theme.DateRoadTheme
-import java.time.LocalDate
-import java.time.format.DateTimeFormatter
 
 @Composable
 fun EnrollRoute(

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/enroll/EnrollScreen.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/enroll/EnrollScreen.kt
@@ -28,8 +28,6 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
-import java.time.LocalDate
-import java.time.format.DateTimeFormatter
 import org.sopt.dateroad.R
 import org.sopt.dateroad.domain.model.Place
 import org.sopt.dateroad.domain.type.RegionType
@@ -49,6 +47,7 @@ import org.sopt.dateroad.presentation.ui.component.dialog.DateRoadOneButtonDialo
 import org.sopt.dateroad.presentation.ui.component.textfield.model.TextFieldValidateResult
 import org.sopt.dateroad.presentation.ui.component.topbar.DateRoadBasicTopBar
 import org.sopt.dateroad.presentation.ui.component.view.DateRoadErrorView
+import org.sopt.dateroad.presentation.ui.component.view.DateRoadLoadingView
 import org.sopt.dateroad.presentation.ui.enroll.component.EnrollPhotos
 import org.sopt.dateroad.presentation.util.DatePicker
 import org.sopt.dateroad.presentation.util.EnrollScreen.MAX_ITEMS
@@ -57,6 +56,8 @@ import org.sopt.dateroad.presentation.util.TimePicker
 import org.sopt.dateroad.presentation.util.view.LoadState
 import org.sopt.dateroad.ui.theme.DATEROADTheme
 import org.sopt.dateroad.ui.theme.DateRoadTheme
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 @Composable
 fun EnrollRoute(
@@ -179,6 +180,8 @@ fun EnrollRoute(
         LoadState.Success -> {
             viewModel.setEvent(EnrollContract.EnrollEvent.SetIsEnrollSuccessDialogOpen(isEnrollSuccessDialogOpen = true))
         }
+
+        LoadState.Loading -> DateRoadLoadingView()
 
         LoadState.Error -> DateRoadErrorView()
 

--- a/app/src/main/java/org/sopt/dateroad/presentation/util/modifier/ModifierExt.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/util/modifier/ModifierExt.kt
@@ -30,16 +30,16 @@ inline fun Modifier.noRippleClickable(
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun Modifier.noRippleDebounceClickable(
-    onClick: () -> Unit
+    onClick: suspend () -> Unit
 ): Modifier = composed {
     var clickable by remember { mutableStateOf(true) }
 
     pointerInteropFilter {
         if (clickable) {
-            onClick()
             clickable = false
             CoroutineScope(Dispatchers.Main).launch {
-                delay(500) // 500밀리초 딜레이
+                onClick()
+                delay(500)
                 clickable = true
             }
         }


### PR DESCRIPTION
## Related issue 🛠
- closed #226 

## Work Description ✏️
- 버튼이 중복 클릭되는 문제를 해결하였습니다.

## Screenshot 📸

https://github.com/user-attachments/assets/a00004c7-4ca9-4e2f-89f0-58052ac8decb

아무튼 연속 클릭 하고 있는 거임,,!


## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
1. noRippleDebounceClickable에 suspend 추가
기존에 0.5초의 딜레이를 주어 중복 클릭을 막아두었지만, 서버 통신에서 0.5초 이상의 시간이 걸리는 경우 (멀티파트라 아무래도 오래 걸리는 듯요 ㅠㅠ) 요청이 여러 번 가는 문제를 확인했습니다. 그래서 Clickable 함수에 suspend를 추가하고 로직을 일부 수정하여 **서버통신 완료 후** 0.5초의 딜레이를 주는 것으로 로직을 변경하였습니다.
2. EnrollScreen에 LodingView 추가
EnrollScreen에 로딩뷰를 추가해두지 않아 중복 클릭의 위험이 더 증가한다고 판단하였습니다. 따라서 이를 방지하고자 (+ 다른 뷰와의 통일성을 유지하고자) EnrollScreen에 로딩뷰를 추가하였습니다.