### PR TITLE
[feat] 내가 등록한 코스 -> 코스 상세 페이지 이동 기능 구현

### DIFF
--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/mycourse/MyCourseContract.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/mycourse/MyCourseContract.kt
@@ -15,6 +15,8 @@ class MyCourseContract {
     ) : UiState
 
     sealed interface MyCourseSideEffect : UiSideEffect {
+        data class NavigateToEnroll(val courseId: Int) : MyCourseSideEffect
+        data class NavigateToCourseDetail(val courseId: Int) : MyCourseSideEffect
         data object PopBackStack : MyCourseSideEffect
     }
 

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/mycourse/MyCourseScreen.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/mycourse/MyCourseScreen.kt
@@ -40,6 +40,7 @@ fun MyCourseRoute(
     viewModel: MyCourseViewModel = hiltViewModel(),
     popBackStack: () -> Unit,
     navigateToEnroll: (EnrollType, Int?) -> Unit,
+    navigateToCourseDetail: (Int) -> Unit,
     myCourseType: MyCourseType
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -60,6 +61,8 @@ fun MyCourseRoute(
         viewModel.sideEffect.flowWithLifecycle(lifecycle = lifecycleOwner.lifecycle)
             .collect { myCourseSideEffect ->
                 when (myCourseSideEffect) {
+                    is MyCourseContract.MyCourseSideEffect.NavigateToEnroll -> navigateToEnroll(EnrollType.TIMELINE, myCourseSideEffect.courseId)
+                    is MyCourseContract.MyCourseSideEffect.NavigateToCourseDetail -> navigateToCourseDetail(myCourseSideEffect.courseId)
                     is MyCourseContract.MyCourseSideEffect.PopBackStack -> popBackStack()
                 }
             }
@@ -75,7 +78,8 @@ fun MyCourseRoute(
                 padding = padding,
                 myCourseUiState = uiState,
                 onIconClick = popBackStack,
-                onCourseCardClick = navigateToEnroll
+                navigateToEnroll = { courseId -> viewModel.setSideEffect(MyCourseContract.MyCourseSideEffect.NavigateToEnroll(courseId = courseId)) },
+                navigateToCourseDetail = { courseId -> viewModel.setSideEffect(MyCourseContract.MyCourseSideEffect.NavigateToCourseDetail(courseId = courseId)) }
             )
         }
 
@@ -88,7 +92,8 @@ fun MyCourseScreen(
     padding: PaddingValues,
     myCourseUiState: MyCourseContract.MyCourseUiState = MyCourseContract.MyCourseUiState(),
     onIconClick: () -> Unit,
-    onCourseCardClick: (EnrollType, Int?) -> Unit
+    navigateToEnroll: (Int) -> Unit,
+    navigateToCourseDetail: (Int) -> Unit
 ) {
     Column(
         modifier = Modifier
@@ -123,8 +128,8 @@ fun MyCourseScreen(
                     course = course,
                     onClick = {
                         when (myCourseUiState.myCourseType) {
-                            MyCourseType.ENROLL -> {}
-                            MyCourseType.READ -> onCourseCardClick(EnrollType.TIMELINE, course.courseId)
+                            MyCourseType.ENROLL -> navigateToCourseDetail(course.courseId)
+                            MyCourseType.READ -> navigateToEnroll(course.courseId)
                         }
                     }
                 )
@@ -182,7 +187,8 @@ fun MyCourseScreenPreview() {
                 )
             ),
             onIconClick = {},
-            onCourseCardClick = { _, _ -> }
+            navigateToEnroll = {},
+            navigateToCourseDetail = {}
         )
     }
 }

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/mycourse/navigation/MyCourseNavigation.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/mycourse/navigation/MyCourseNavigation.kt
@@ -18,7 +18,8 @@ fun NavController.navigateMyCourses(myCourseType: MyCourseType) {
 fun NavGraphBuilder.myCoursesNavGraph(
     padding: PaddingValues,
     popBackStack: () -> Unit,
-    navigateToEnroll: (EnrollType, Int?) -> Unit
+    navigateToEnroll: (EnrollType, Int?) -> Unit,
+    navigateToCourseDetail: (Int) -> Unit
 ) {
     composable(
         route = ROUTE_WITH_ARGUMENT,
@@ -32,7 +33,7 @@ fun NavGraphBuilder.myCoursesNavGraph(
             MyCourseType.valueOf(it)
         } ?: MyCourseType.ENROLL
 
-        MyCourseRoute(padding = padding, popBackStack = popBackStack, myCourseType = myCourseType, navigateToEnroll = navigateToEnroll)
+        MyCourseRoute(padding = padding, popBackStack = popBackStack, myCourseType = myCourseType, navigateToEnroll = navigateToEnroll, navigateToCourseDetail = navigateToCourseDetail)
     }
 }
 

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/navigator/MainNavigator.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/navigator/MainNavigator.kt
@@ -143,17 +143,6 @@ class MainNavigator(
         navHostController.navigationSignIn()
     }
 
-    fun navigateTimeline(navOptions: NavOptions? = null) {
-        navHostController.navigationTimeline(
-            navOptions ?: navOptions {
-                popUpTo(navHostController.graph.findStartDestination().id) {
-                    inclusive = true
-                }
-                launchSingleTop = true
-            }
-        )
-    }
-
     fun navigateToTimelineDetail(timelineType: TimelineType, dateId: Int) {
         navHostController.navigateToTimelineDetail(timelineType, dateId)
     }

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/navigator/component/MainNavHost.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/navigator/component/MainNavHost.kt
@@ -77,7 +77,8 @@ fun MainNavHost(
             myCoursesNavGraph(
                 padding = padding,
                 popBackStack = navigator::popBackStackIfNotHome,
-                navigateToEnroll = navigator::navigateToEnroll
+                navigateToEnroll = navigator::navigateToEnroll,
+                navigateToCourseDetail = navigator::navigateToCourseDetail
             )
 
             myPageNavGraph(


### PR DESCRIPTION
## Related issue 🛠
- closed #230 

## Work Description ✏️
- 내가 등록한 코스에서 아이템 클릭 시 코스 상세 페이지로 이동할 수 있는 기능을 구현합니다.

## Screenshot 📸
https://github.com/user-attachments/assets/3e9f7c4f-478a-4da7-981a-50517e94c47f


## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
스택 관리는 스택 관리 이슈에서 한 번에 진행할게요.