### PR TITLE
[fix] 더보기를 통한 이동 시 스택이 쌓이는 문제 해결

### DIFF
--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/home/HomeScreen.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/home/HomeScreen.kt
@@ -40,6 +40,7 @@ import org.sopt.dateroad.R
 import org.sopt.dateroad.domain.model.NearestTimeline
 import org.sopt.dateroad.domain.type.SortByType
 import org.sopt.dateroad.presentation.type.EnrollType
+import org.sopt.dateroad.presentation.type.MainNavigationBarItemType
 import org.sopt.dateroad.presentation.type.TagType
 import org.sopt.dateroad.presentation.type.TimelineType
 import org.sopt.dateroad.presentation.ui.component.button.DateRoadImageButton
@@ -63,7 +64,7 @@ fun HomeRoute(
     padding: PaddingValues,
     viewModel: HomeViewModel = hiltViewModel(),
     navigateToPointHistory: () -> Unit,
-    navigateToLook: () -> Unit,
+    navigateToLook: (MainNavigationBarItemType) -> Unit,
     navigateToTimelineDetail: (TimelineType, Int) -> Unit,
     navigateToEnroll: (EnrollType, Int?) -> Unit,
     navigateToAdvertisementDetail: (Int) -> Unit,
@@ -97,7 +98,7 @@ fun HomeRoute(
             .collect { homeSideEffect ->
                 when (homeSideEffect) {
                     is HomeContract.HomeSideEffect.NavigateToPointHistory -> navigateToPointHistory()
-                    is HomeContract.HomeSideEffect.NavigateToLook -> navigateToLook()
+                    is HomeContract.HomeSideEffect.NavigateToLook -> navigateToLook(MainNavigationBarItemType.LOOK)
                     is HomeContract.HomeSideEffect.NavigateToTimelineDetail -> navigateToTimelineDetail(homeSideEffect.timelineType, homeSideEffect.timelineId)
                     is HomeContract.HomeSideEffect.NavigateToEnroll -> navigateToEnroll(homeSideEffect.enrollType, homeSideEffect.id)
                     is HomeContract.HomeSideEffect.NavigateToAdvertisementDetail -> navigateToAdvertisementDetail(homeSideEffect.advertisementId)

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/home/navigation/HomeNavigation.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/home/navigation/HomeNavigation.kt
@@ -7,6 +7,7 @@ import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import org.sopt.dateroad.presentation.model.MainNavigationBarRoute
 import org.sopt.dateroad.presentation.type.EnrollType
+import org.sopt.dateroad.presentation.type.MainNavigationBarItemType
 import org.sopt.dateroad.presentation.type.TimelineType
 import org.sopt.dateroad.presentation.ui.home.HomeRoute
 
@@ -20,7 +21,7 @@ fun NavController.navigationHome(navOptions: NavOptions) {
 fun NavGraphBuilder.homeNavGraph(
     padding: PaddingValues,
     navigateToPointHistory: () -> Unit,
-    navigateToLook: () -> Unit,
+    navigateToLook: (MainNavigationBarItemType) -> Unit,
     navigateToTimelineDetail: (TimelineType, Int) -> Unit,
     navigateToEnroll: (EnrollType, Int?) -> Unit,
     navigateToAdvertisement: (Int) -> Unit,

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/navigator/MainNavigator.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/navigator/MainNavigator.kt
@@ -100,17 +100,6 @@ class MainNavigator(
         )
     }
 
-    fun navigateToLook(navOptions: NavOptions? = null) {
-        navHostController.navigationLook(
-            navOptions ?: navOptions {
-                popUpTo(navHostController.graph.findStartDestination().id) {
-                    inclusive = true
-                }
-                launchSingleTop = true
-            }
-        )
-    }
-
     fun navigateToMyCourse(myCourseType: MyCourseType) {
         navHostController.navigateMyCourses(myCourseType = myCourseType)
     }
@@ -141,17 +130,6 @@ class MainNavigator(
 
     fun navigateToSignIn() {
         navHostController.navigationSignIn()
-    }
-
-    fun navigateTimeline(navOptions: NavOptions? = null) {
-        navHostController.navigationTimeline(
-            navOptions ?: navOptions {
-                popUpTo(navHostController.graph.findStartDestination().id) {
-                    inclusive = true
-                }
-                launchSingleTop = true
-            }
-        )
     }
 
     fun navigateToTimelineDetail(timelineType: TimelineType, dateId: Int) {

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/navigator/component/MainNavHost.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/navigator/component/MainNavHost.kt
@@ -61,7 +61,7 @@ fun MainNavHost(
             homeNavGraph(
                 padding = padding,
                 navigateToPointHistory = navigator::navigateToPointHistory,
-                navigateToLook = navigator::navigateToLook,
+                navigateToLook = navigator::navigateMainNavigation,
                 navigateToTimelineDetail = navigator::navigateToTimelineDetail,
                 navigateToEnroll = navigator::navigateToEnroll,
                 navigateToAdvertisement = navigator::navigateToAdvertisement,

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/navigator/component/MainNavHost.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/navigator/component/MainNavHost.kt
@@ -135,8 +135,7 @@ fun MainNavHost(
                 padding = padding,
                 navigateToPast = navigator::navigateToPast,
                 navigateToEnroll = navigator::navigateToEnroll,
-                navigateToTimelineDetail = navigator::navigateToTimelineDetail,
-                popBackStack = navigator::popBackStackIfNotHome
+                navigateToTimelineDetail = navigator::navigateToTimelineDetail
             )
 
             timelineDetailGraph(

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/timeline/navigation/TimelineNavigation.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/timeline/navigation/TimelineNavigation.kt
@@ -21,8 +21,7 @@ fun NavGraphBuilder.timelineNavGraph(
     padding: PaddingValues,
     navigateToPast: () -> Unit,
     navigateToEnroll: (EnrollType, Int?) -> Unit,
-    navigateToTimelineDetail: (TimelineType, Int) -> Unit,
-    popBackStack: () -> Unit
+    navigateToTimelineDetail: (TimelineType, Int) -> Unit
 ) {
     composable(route = MainNavigationBarRoute.Timeline::class.simpleName.orEmpty()) {
         TimelineRoute(


### PR DESCRIPTION
## Related issue 🛠
- closed #232 

## Work Description ✏️
- 홈 뷰에서 더보기를 통한 바텀 네비 이동 시 스택이 쌓여 바텀 네비가 동작하지 않는 문제를 해결했습니다.

## Screenshot 📸
https://github.com/user-attachments/assets/c7c37248-4216-4e9a-8dfa-5b9801b81f17

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
바텀 네비에 있는 뷰로 화면 전환을 할 때는 바텀 네비를 전환시키는 함수 (navigateMainNavigation)를 사용하여야 하는데 그걸 안 사용하고 일반적으로 뷰를 전환하는 로직을 사용해 화면 전환을 구현하였더라구요 ㅠㅠ (왜 그랬지 ㅜㅜ) navigateMainNavigation을 활용하는 방식으로 수정했는데 혹시 또 바텀 네비 스택 관리가 안 되는 부분이 발견되면 말씀해주세용