### PR TITLE
[chore] 포인트 사용 [유저 데이트 코스 열람] API description 변경

### DIFF
--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/coursedetail/CourseDetailViewModel.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/coursedetail/CourseDetailViewModel.kt
@@ -90,7 +90,7 @@ class CourseDetailViewModel @Inject constructor(
     fun postUsePoint(courseId: Int) {
         viewModelScope.launch {
             setEvent(CourseDetailContract.CourseDetailEvent.PostUsePoint(usePointLoadState = LoadState.Loading))
-            postUsePointUseCase(courseId = courseId, usePoint = UsePoint(Point.POINT, Point.POINT_USED, "${currentState.courseDetail.title} 코스 열람")).onSuccess {
+            postUsePointUseCase(courseId = courseId, usePoint = UsePoint(point = Point.POINT, type = Point.POINT_USED, description = Point.POINT_USED_DESCRIPTION)).onSuccess {
                 setEvent(CourseDetailContract.CourseDetailEvent.PostUsePoint(usePointLoadState = LoadState.Success))
             }.onFailure {
                 setEvent(CourseDetailContract.CourseDetailEvent.PostUsePoint(usePointLoadState = LoadState.Error))

--- a/app/src/main/java/org/sopt/dateroad/presentation/util/Constraints.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/util/Constraints.kt
@@ -39,6 +39,7 @@ object Default {
 object Point {
     const val POINT = 50
     const val POINT_USED = "POINT_USED"
+    const val POINT_USED_DESCRIPTION = "코스 열람하기"
 }
 
 object Token {
@@ -48,3 +49,5 @@ object Token {
 object Time {
     const val TIME = " 시간"
 }
+
+// object


### PR DESCRIPTION
## Related issue 🛠
- closed #236 

## Work Description ✏️
-포인트 사용 [유저 데이트 코스 열람] API의 description을 변경합니다.

## Screenshot 📸
<img width="507" alt="스크린샷 2024-09-02 오후 7 41 19" src="https://github.com/user-attachments/assets/21e3e212-d6b7-4414-805b-feca94b95f7c">
<img width="407" alt="스크린샷 2024-09-10 오전 10 46 07" src="https://github.com/user-attachments/assets/baf1e0fa-1b6f-4d18-8e6a-2224e92ac0b8">


## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
지금,, 무료 열람 기회 차감이 안 되고 있어서 포인트 내역 (PointHistory) 뷰에서 잘 반영이 되었는지는 확인을 못 했어요,,! 서버 측에 얘기해놓은 상태이고 해결되면 스크린샷 업데이트 하도록 하겠습니다.
-> 반영 완 ~