### PR TITLE
[fix] 리이슈 중복 호출 후 마지막 호출에 의한 통신만 재전송하는 문제 해결

### DIFF
--- a/app/src/main/java/org/sopt/dateroad/data/dataremote/interceptor/AuthInterceptor.kt
+++ b/app/src/main/java/org/sopt/dateroad/data/dataremote/interceptor/AuthInterceptor.kt
@@ -2,12 +2,13 @@ package org.sopt.dateroad.data.dataremote.interceptor
 
 import android.app.Application
 import android.content.Intent
-import java.lang.IllegalStateException
-import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.Json
 import okhttp3.Interceptor
 import okhttp3.Request
@@ -26,57 +27,18 @@ class AuthInterceptor @Inject constructor(
     private val localStorage: UserInfoLocalDataSource,
     private val context: Application
 ) : Interceptor {
-    private val isRefreshing = AtomicBoolean(false)
+
+    private val mutex = Mutex()
 
     override fun intercept(chain: Interceptor.Chain): Response {
         val originalRequest = chain.request()
         val authRequest = if (localStorage.accessToken.isNotBlank()) originalRequest.newAuthBuilder() else originalRequest
-        val response = chain.proceed(authRequest)
+        var response = chain.proceed(authRequest)
 
         when (response.code) {
             CODE_TOKEN_EXPIRE -> {
                 response.close()
-
-                if (isRefreshing.compareAndSet(false, true)) {
-                    try {
-                        val refreshTokenRequest = originalRequest.newBuilder()
-                            .patch("".toRequestBody(null))
-                            .url("${BuildConfig.BASE_URL}$API/$VERSION/$USERS/$REISSUE")
-                            .addHeader(AUTHORIZATION, localStorage.refreshToken)
-                            .build()
-
-                        val refreshTokenResponse = chain.proceed(refreshTokenRequest)
-
-                        if (refreshTokenResponse.isSuccessful) {
-                            val responseRefresh = json.decodeFromString<ResponseRefreshTokenDto>(
-                                refreshTokenResponse.body?.string()
-                                    ?: throw IllegalStateException("\"refreshTokenResponse is null $refreshTokenResponse\"")
-                            )
-
-                            with(localStorage) {
-                                accessToken = BEARER + responseRefresh.accessToken
-                                refreshToken = responseRefresh.refreshToken
-                            }
-                            refreshTokenResponse.close()
-
-                            val newRequest = originalRequest.newAuthBuilder()
-                            return chain.proceed(newRequest)
-                        } else {
-                            with(context) {
-                                CoroutineScope(Dispatchers.Main).launch {
-                                    startActivity(
-                                        Intent.makeRestartActivityTask(
-                                            packageManager.getLaunchIntentForPackage(packageName)?.component
-                                        )
-                                    )
-                                    localStorage.clear()
-                                }
-                            }
-                        }
-                    } finally {
-                        isRefreshing.set(false)
-                    }
-                }
+                response = handleTokenExpiration(chain = chain, originalRequest = originalRequest, requestAccessToken = localStorage.accessToken)
             }
         }
 
@@ -85,6 +47,69 @@ class AuthInterceptor @Inject constructor(
 
     private fun Request.newAuthBuilder() =
         this.newBuilder().addHeader(AUTHORIZATION, localStorage.accessToken).build()
+
+    private fun handleTokenExpiration(chain: Interceptor.Chain, originalRequest: Request, requestAccessToken: String): Response =
+        runBlocking {
+            mutex.withLock {
+                when (isTokenValid(requestAccessToken = requestAccessToken, currentAccessToken = localStorage.accessToken)) {
+                    true -> chain.proceed(originalRequest.newAuthBuilder())
+                    false -> handleTokenRefresh(chain = chain, originalRequest = originalRequest, refreshToken = localStorage.refreshToken)
+                }
+            }
+        }
+
+    private fun isTokenValid(requestAccessToken: String, currentAccessToken: String): Boolean = requestAccessToken != currentAccessToken && currentAccessToken.isNotBlank()
+
+    private fun handleTokenRefresh(chain: Interceptor.Chain, originalRequest: Request, refreshToken: String): Response =
+        patchTokenRefresh(chain = chain, originalRequest = originalRequest, refreshToken = refreshToken).let { refreshTokenResponse ->
+            when (refreshTokenResponse.isSuccessful) {
+                true -> handleTokenRefreshSuccess(chain = chain, originalRequest = originalRequest, refreshTokenResponse = refreshTokenResponse)
+                false -> handleTokenRefreshFailed(refreshTokenResponse = refreshTokenResponse)
+            }
+        }
+
+    private fun patchTokenRefresh(chain: Interceptor.Chain, originalRequest: Request, refreshToken: String): Response = chain.proceed(
+        originalRequest.newBuilder()
+            .patch("".toRequestBody(null))
+            .url("${BuildConfig.BASE_URL}$API/$VERSION/$USERS/$REISSUE")
+            .addHeader(AUTHORIZATION, refreshToken)
+            .build()
+    )
+
+    private fun handleTokenRefreshSuccess(chain: Interceptor.Chain, originalRequest: Request, refreshTokenResponse: Response): Response {
+        val responseRefreshToken = json.decodeFromString<ResponseRefreshTokenDto>(
+            refreshTokenResponse.body?.string() ?: throw IllegalStateException("\"refreshTokenResponse is null $refreshTokenResponse\"")
+        )
+
+        with(localStorage) {
+            accessToken = BEARER + responseRefreshToken.accessToken
+            refreshToken = responseRefreshToken.refreshToken
+        }
+
+        refreshTokenResponse.close()
+
+        return chain.proceed(originalRequest.newAuthBuilder())
+    }
+
+    private fun handleTokenRefreshFailed(refreshTokenResponse: Response): Response {
+        refreshTokenResponse.close()
+
+        CoroutineScope(Dispatchers.Main).launch {
+            with(context) {
+                CoroutineScope(Dispatchers.Main).launch {
+                    startActivity(
+                        Intent.makeRestartActivityTask(
+                            packageManager.getLaunchIntentForPackage(packageName)?.component
+                        )
+                    )
+                }
+            }
+        }
+
+        localStorage.clear()
+
+        return refreshTokenResponse
+    }
 
     companion object {
         const val CODE_TOKEN_EXPIRE = 401


### PR DESCRIPTION
## Related issue 🛠
- closed #204 

## Work Description ✏️
- 리이슈 중복 호출 후 마지막 호출에 의한 통신만 재전송하는 문제를 해결하였습니다.

## Screenshot 📸
<img width="442" alt="스크린샷 2024-09-04 오후 2 54 36" src="https://github.com/user-attachments/assets/040132c5-1758-496e-850c-6a21c23b1a35">


## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
1. 토큰 재발급 중복 호출 문제를 해결하였습니다.
- 기존에는 AtomicBoolean을 이용하였는데 Mutex를 이용하는 방식으로 수정하였습니다. (동시성 문제는 보통 Mutex를 이용해 해결한다고 하더라구요 엄마 체고 ㅠ)
Mutex에 lock을 걸어서 한 번에 하나의 재발급 요청이 이루어지도록 하였습니다. (이전 재발급 요청이 완료되지 않은 경우 재발급 요청을 보내지 못하도록 구현)

- 재발급이 완료된 후 새로운 액세스 토큰이 아닌 기존의 액세스 토큰을 이용해 요청을 보내는 경우 (현재 로컬에 저장된 액세스 토큰과 요청을 보낼 때 사용되는 액세스 토큰 값이 다른 경우) 현재 로컬에 저장된 액세스 토큰으로 새로운 리퀘스트를 만들어 요청을 보내도록 하였습니다.