### PR TITLE
[chore] 코스 상세 하단 버튼 크기 조정

### DIFF
--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/coursedetail/component/CourseDetailBottomBar.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/coursedetail/component/CourseDetailBottomBar.kt
@@ -55,10 +55,12 @@ fun CourseDetailBottomBar(
 @Preview
 @Composable
 fun ButtonPreview(modifier: Modifier = Modifier) {
-    Box(modifier = Modifier){
-        CourseDetailBottomBar(modifier = Modifier.align(Alignment.BottomCenter),
+    Box(modifier = Modifier) {
+        CourseDetailBottomBar(
+            modifier = Modifier.align(Alignment.BottomCenter),
             isUserLiked = true,
-            onLikeButtonClicked = {  },
-            onEnrollButtonClicked = {  })
+            onLikeButtonClicked = { },
+            onEnrollButtonClicked = { }
+        )
     }
 }

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/coursedetail/component/CourseDetailBottomBar.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/coursedetail/component/CourseDetailBottomBar.kt
@@ -1,14 +1,17 @@
 package org.sopt.dateroad.presentation.ui.coursedetail.component
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.sopt.dateroad.R
 import org.sopt.dateroad.presentation.ui.component.button.DateRoadBasicButton
@@ -38,7 +41,7 @@ fun CourseDetailBottomBar(
             onClick = onLikeButtonClicked,
             cornerRadius = 14.dp,
             paddingHorizontal = 23.dp,
-            paddingVertical = 18.dp
+            paddingVertical = 16.5.dp
         )
         Spacer(modifier = Modifier.width(12.dp))
         DateRoadBasicButton(
@@ -46,5 +49,16 @@ fun CourseDetailBottomBar(
             textContent = stringResource(id = R.string.course_detail_get_course),
             onClick = onEnrollButtonClicked
         )
+    }
+}
+
+@Preview
+@Composable
+fun ButtonPreview(modifier: Modifier = Modifier) {
+    Box(modifier = Modifier){
+        CourseDetailBottomBar(modifier = Modifier.align(Alignment.BottomCenter),
+            isUserLiked = true,
+            onLikeButtonClicked = {  },
+            onEnrollButtonClicked = {  })
     }
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #249

## Work Description ✏️
- 좋아요 버튼과  내 일정에 등록하기 버튼의 세로 길이를 일치시켰습니다!

## Screenshot 📸

<img width="622" alt="image" src="https://github.com/user-attachments/assets/26fb83f4-b03f-4874-95ea-360bcb242bd8">

<img width="333" alt="image" src="https://github.com/user-attachments/assets/841bd924-b2b1-4ee6-84c4-a3d13a195389">


## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
똑같아 보이나...? 피그마에 나온 값이 좀 이상한데 한번 더 같이 체크해봐요!