### PR TITLE
[feat] 데이트 일정 상세 뷰 앰플리튜드 트래킹 이벤트 코드 심기

### DIFF
--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/navigator/component/MainNavHost.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/navigator/component/MainNavHost.kt
@@ -143,7 +143,8 @@ fun MainNavHost(
             )
 
             timelineDetailGraph(
-                popBackStack = navigator::popBackStackIfNotHome
+                popBackStack = navigator::popBackStackIfNotHome,
+                navController = navigator.navHostController
             )
         }
     }

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/navigator/component/MainNavHost.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/navigator/component/MainNavHost.kt
@@ -26,6 +26,8 @@ import org.sopt.dateroad.presentation.ui.read.navigation.readNavGraph
 import org.sopt.dateroad.presentation.ui.signin.navigation.signInGraph
 import org.sopt.dateroad.presentation.ui.timeline.navigation.timelineNavGraph
 import org.sopt.dateroad.presentation.ui.timelinedetail.navigation.timelineDetailGraph
+import org.sopt.dateroad.presentation.util.ViewPath.HOME
+import org.sopt.dateroad.presentation.util.ViewPath.TIMELINE
 import org.sopt.dateroad.ui.theme.DateRoadTheme
 
 @Composable
@@ -142,9 +144,17 @@ fun MainNavHost(
                 navigateToTimelineDetail = navigator::navigateToTimelineDetail
             )
 
+            val previousRoute = navigator.navHostController.previousBackStackEntry?.destination?.route ?: "Unknown"
+
+            val previousView = when (previousRoute) {
+                HOME -> "홈"
+                TIMELINE -> "데이트 일정"
+                else -> "Unknown"
+            }
+
             timelineDetailGraph(
                 popBackStack = navigator::popBackStackIfNotHome,
-                navController = navigator.navHostController
+                viewPath= previousView
             )
         }
     }

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/navigator/component/MainNavHost.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/navigator/component/MainNavHost.kt
@@ -154,7 +154,7 @@ fun MainNavHost(
 
             timelineDetailGraph(
                 popBackStack = navigator::popBackStackIfNotHome,
-                viewPath= previousView
+                viewPath = previousView
             )
         }
     }

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/timelinedetail/TimelineDetailScreen.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/timelinedetail/TimelineDetailScreen.kt
@@ -94,7 +94,6 @@ fun TimelineDetailRoute(
     }
 
     LaunchedEffect(uiState.loadState, lifecycleOwner) {
-        Log.d("ㅋㅋ", "$previousView")
         if (uiState.loadState == LoadState.Success) {
             AmplitudeUtils.trackEventWithProperty(
                 eventName = VIEW_SCHEDULE_DETAILS,

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/timelinedetail/TimelineDetailScreen.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/timelinedetail/TimelineDetailScreen.kt
@@ -1,6 +1,5 @@
 package org.sopt.dateroad.presentation.ui.timelinedetail
 
-import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/timelinedetail/TimelineDetailScreen.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/timelinedetail/TimelineDetailScreen.kt
@@ -322,7 +322,7 @@ fun TimelineDetailScreen(
                     mapOf(
                         DATE_COURSE_NUM to uiState.timelineDetail.places.size,
                         DATE_TOTAL_DURATION to uiState.timelineDetail.places.sumOf { place ->
-                            place.duration.replace("시간", "").trim().toIntOrNull() ?: 0
+                            durationToInt(place.duration)
                         }
                     )
                 )
@@ -409,4 +409,8 @@ fun TimelineDetailScreenPreview() {
             onKakaoShareConfirm = {}
         )
     }
+}
+
+fun durationToInt(duration:String):Int{
+   return duration.replace("시간", "").trim().toIntOrNull() ?: 0
 }

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/timelinedetail/TimelineDetailScreen.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/timelinedetail/TimelineDetailScreen.kt
@@ -1,5 +1,6 @@
 package org.sopt.dateroad.presentation.ui.timelinedetail
 
+import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -71,7 +72,8 @@ import org.sopt.dateroad.ui.theme.DateRoadTheme
 fun TimelineDetailRoute(
     popBackStack: () -> Unit,
     timelineId: Int,
-    timelineType: TimelineType
+    timelineType: TimelineType,
+    previousView: String
 ) {
     val viewModel: TimelineDetailViewModel = hiltViewModel()
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -92,7 +94,14 @@ fun TimelineDetailRoute(
     }
 
     LaunchedEffect(uiState.loadState, lifecycleOwner) {
-        if (uiState.loadState == LoadState.Success) AmplitudeUtils.trackEventWithProperty(eventName = VIEW_SCHEDULE_DETAILS, propertyName = VIEW_PATH, propertyValue = "Test Value")
+        Log.d("ㅋㅋ", "$previousView")
+        if (uiState.loadState == LoadState.Success) {
+            AmplitudeUtils.trackEventWithProperty(
+                eventName = VIEW_SCHEDULE_DETAILS,
+                propertyName = VIEW_PATH,
+                propertyValue = previousView
+            )
+        }
     }
 
     when (uiState.loadState) {

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/timelinedetail/TimelineDetailScreen.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/timelinedetail/TimelineDetailScreen.kt
@@ -54,6 +54,14 @@ import org.sopt.dateroad.presentation.ui.component.topbar.DateRoadBasicTopBar
 import org.sopt.dateroad.presentation.ui.component.view.DateRoadErrorView
 import org.sopt.dateroad.presentation.ui.component.view.DateRoadIdleView
 import org.sopt.dateroad.presentation.ui.component.view.DateRoadLoadingView
+import org.sopt.dateroad.presentation.util.TimelineDetailAmplitude.CLICK_CLOSE_KAKAO
+import org.sopt.dateroad.presentation.util.TimelineDetailAmplitude.CLICK_KAKAO_SHARE
+import org.sopt.dateroad.presentation.util.TimelineDetailAmplitude.CLICK_OPEN_KAKAO
+import org.sopt.dateroad.presentation.util.TimelineDetailAmplitude.DATE_COURSE_NUM
+import org.sopt.dateroad.presentation.util.TimelineDetailAmplitude.DATE_TOTAL_DURATION
+import org.sopt.dateroad.presentation.util.TimelineDetailAmplitude.VIEW_PATH
+import org.sopt.dateroad.presentation.util.TimelineDetailAmplitude.VIEW_SCHEDULE_DETAILS
+import org.sopt.dateroad.presentation.util.amplitude.AmplitudeUtils
 import org.sopt.dateroad.presentation.util.modifier.noRippleClickable
 import org.sopt.dateroad.presentation.util.view.LoadState
 import org.sopt.dateroad.ui.theme.DATEROADTheme
@@ -83,6 +91,10 @@ fun TimelineDetailRoute(
             }
     }
 
+    LaunchedEffect(uiState.loadState, lifecycleOwner) {
+        if (uiState.loadState == LoadState.Success) AmplitudeUtils.trackEventWithProperty(eventName = VIEW_SCHEDULE_DETAILS, propertyName = VIEW_PATH, propertyValue = "Test Value")
+    }
+
     when (uiState.loadState) {
         LoadState.Idle -> DateRoadIdleView()
 
@@ -94,7 +106,18 @@ fun TimelineDetailRoute(
                 timelineType = timelineType,
                 onTopBarItemClick = popBackStack,
                 onButtonClick = { viewModel.setEvent(TimelineDetailContract.TimelineDetailEvent.SetShowDeleteBottomSheet(true)) },
-                showKakaoClicked = { viewModel.setEvent(TimelineDetailContract.TimelineDetailEvent.SetShowKakaoDialog(true)) },
+                showKakaoClicked = {
+                    viewModel.setEvent(TimelineDetailContract.TimelineDetailEvent.SetShowKakaoDialog(true))
+                    AmplitudeUtils.trackEventWithProperties(
+                        eventName = CLICK_KAKAO_SHARE,
+                        mapOf(
+                            DATE_COURSE_NUM to uiState.timelineDetail.places.size,
+                            DATE_TOTAL_DURATION to uiState.timelineDetail.places.sumOf { place ->
+                                place.duration.replace("시간", "").trim().toIntOrNull() ?: 0
+                            }
+                        )
+                    )
+                },
                 setShowKakaoDialog = { showKakaoDialog -> viewModel.setEvent(TimelineDetailContract.TimelineDetailEvent.SetShowKakaoDialog(showKakaoDialog)) },
                 setShowDeleteBottomSheet = { showDeleteBottomSheet -> viewModel.setEvent(TimelineDetailContract.TimelineDetailEvent.SetShowDeleteBottomSheet(showDeleteBottomSheet)) },
                 setShowDeleteDialog = { showDeleteDialog -> viewModel.setEvent(TimelineDetailContract.TimelineDetailEvent.SetShowDeleteDialog(showDeleteDialog)) },
@@ -287,9 +310,29 @@ fun TimelineDetailScreen(
             onDismissRequest = { setShowKakaoDialog(false) },
             onClickConfirm = {
                 setShowKakaoDialog(false)
+                AmplitudeUtils.trackEventWithProperties(
+                    eventName = CLICK_OPEN_KAKAO,
+                    mapOf(
+                        DATE_COURSE_NUM to uiState.timelineDetail.places.size,
+                        DATE_TOTAL_DURATION to uiState.timelineDetail.places.sumOf { place ->
+                            place.duration.replace("시간", "").trim().toIntOrNull() ?: 0
+                        }
+                    )
+                )
                 onKakaoShareConfirm()
             },
-            onClickDismiss = { setShowKakaoDialog(false) }
+            onClickDismiss = {
+                setShowKakaoDialog(false)
+                AmplitudeUtils.trackEventWithProperties(
+                    eventName = CLICK_CLOSE_KAKAO,
+                    mapOf(
+                        DATE_COURSE_NUM to uiState.timelineDetail.places.size,
+                        DATE_TOTAL_DURATION to uiState.timelineDetail.places.sumOf { place ->
+                            place.duration.replace("시간", "").trim().toIntOrNull() ?: 0
+                        }
+                    )
+                )
+            }
         )
     }
 

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/timelinedetail/TimelineDetailScreen.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/timelinedetail/TimelineDetailScreen.kt
@@ -54,6 +54,7 @@ import org.sopt.dateroad.presentation.ui.component.topbar.DateRoadBasicTopBar
 import org.sopt.dateroad.presentation.ui.component.view.DateRoadErrorView
 import org.sopt.dateroad.presentation.ui.component.view.DateRoadIdleView
 import org.sopt.dateroad.presentation.ui.component.view.DateRoadLoadingView
+import org.sopt.dateroad.presentation.util.TimelineAmplitude.DURATION
 import org.sopt.dateroad.presentation.util.TimelineDetailAmplitude.CLICK_CLOSE_KAKAO
 import org.sopt.dateroad.presentation.util.TimelineDetailAmplitude.CLICK_KAKAO_SHARE
 import org.sopt.dateroad.presentation.util.TimelineDetailAmplitude.CLICK_OPEN_KAKAO
@@ -120,7 +121,7 @@ fun TimelineDetailRoute(
                         mapOf(
                             DATE_COURSE_NUM to uiState.timelineDetail.places.size,
                             DATE_TOTAL_DURATION to uiState.timelineDetail.places.sumOf { place ->
-                                place.duration.replace("시간", "").trim().toIntOrNull() ?: 0
+                                durationToInt(place.duration)
                             }
                         )
                     )
@@ -335,7 +336,7 @@ fun TimelineDetailScreen(
                     mapOf(
                         DATE_COURSE_NUM to uiState.timelineDetail.places.size,
                         DATE_TOTAL_DURATION to uiState.timelineDetail.places.sumOf { place ->
-                            place.duration.replace("시간", "").trim().toIntOrNull() ?: 0
+                            durationToInt(place.duration)
                         }
                     )
                 )
@@ -412,5 +413,5 @@ fun TimelineDetailScreenPreview() {
 }
 
 fun durationToInt(duration: String): Int {
-    return duration.replace("시간", "").trim().toIntOrNull() ?: 0
+    return duration.replace(DURATION, "").trim().toIntOrNull() ?: 0
 }

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/timelinedetail/TimelineDetailScreen.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/timelinedetail/TimelineDetailScreen.kt
@@ -411,6 +411,6 @@ fun TimelineDetailScreenPreview() {
     }
 }
 
-fun durationToInt(duration:String):Int{
-   return duration.replace("시간", "").trim().toIntOrNull() ?: 0
+fun durationToInt(duration: String): Int {
+    return duration.replace("시간", "").trim().toIntOrNull() ?: 0
 }

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/timelinedetail/navigation/TimelineDetailNavigation.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/timelinedetail/navigation/TimelineDetailNavigation.kt
@@ -8,6 +8,8 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import org.sopt.dateroad.presentation.type.TimelineType
 import org.sopt.dateroad.presentation.ui.timelinedetail.TimelineDetailRoute
+import org.sopt.dateroad.presentation.util.ViewPath.HOME
+import org.sopt.dateroad.presentation.util.ViewPath.TIMELINE
 
 fun NavController.navigateToTimelineDetail(timelineType: TimelineType, timelineId: Int, navOptions: NavOptions? = null) {
     navigate(TimelineDetailRoutes.route(timelineType, timelineId), navOptions)
@@ -30,8 +32,8 @@ fun NavGraphBuilder.timelineDetailGraph(
         val previousRoute = navController.previousBackStackEntry?.destination?.route ?: "Unknown"
 
         val previousView = when (previousRoute) {
-            "Home" -> "홈"
-            "Timeline" -> "데이트 일정"
+            HOME -> "홈"
+            TIMELINE -> "데이트 일정"
             else -> "Unknown"
         }
 

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/timelinedetail/navigation/TimelineDetailNavigation.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/timelinedetail/navigation/TimelineDetailNavigation.kt
@@ -8,8 +8,6 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import org.sopt.dateroad.presentation.type.TimelineType
 import org.sopt.dateroad.presentation.ui.timelinedetail.TimelineDetailRoute
-import org.sopt.dateroad.presentation.util.ViewPath.HOME
-import org.sopt.dateroad.presentation.util.ViewPath.TIMELINE
 
 fun NavController.navigateToTimelineDetail(timelineType: TimelineType, timelineId: Int, navOptions: NavOptions? = null) {
     navigate(TimelineDetailRoutes.route(timelineType, timelineId), navOptions)
@@ -28,8 +26,6 @@ fun NavGraphBuilder.timelineDetailGraph(
     ) { backStackEntry ->
         val timelineType = TimelineType.valueOf(backStackEntry.arguments?.getString(TimelineDetailRoutes.TIMELINE_TYPE) ?: TimelineType.PINK.name)
         val timelineId = backStackEntry.arguments?.getInt(TimelineDetailRoutes.TIMELINE_ID) ?: 1
-
-
 
         TimelineDetailRoute(
             popBackStack = popBackStack,

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/timelinedetail/navigation/TimelineDetailNavigation.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/timelinedetail/navigation/TimelineDetailNavigation.kt
@@ -14,6 +14,7 @@ fun NavController.navigateToTimelineDetail(timelineType: TimelineType, timelineI
 }
 
 fun NavGraphBuilder.timelineDetailGraph(
+    navController: NavController,
     popBackStack: () -> Unit
 ) {
     composable(
@@ -26,10 +27,19 @@ fun NavGraphBuilder.timelineDetailGraph(
         val timelineType = TimelineType.valueOf(backStackEntry.arguments?.getString(TimelineDetailRoutes.TIMELINE_TYPE) ?: TimelineType.PINK.name)
         val timelineId = backStackEntry.arguments?.getInt(TimelineDetailRoutes.TIMELINE_ID) ?: 1
 
+        val previousRoute = navController.previousBackStackEntry?.destination?.route ?: "Unknown"
+
+        val previousView = when (previousRoute) {
+            "Home" -> "홈"
+            "Timeline" -> "데이트 일정"
+            else -> "Unknown"
+        }
+
         TimelineDetailRoute(
             popBackStack = popBackStack,
             timelineId = timelineId,
-            timelineType = timelineType
+            timelineType = timelineType,
+            previousView = previousView
         )
     }
 }

--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/timelinedetail/navigation/TimelineDetailNavigation.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/timelinedetail/navigation/TimelineDetailNavigation.kt
@@ -16,7 +16,7 @@ fun NavController.navigateToTimelineDetail(timelineType: TimelineType, timelineI
 }
 
 fun NavGraphBuilder.timelineDetailGraph(
-    navController: NavController,
+    viewPath: String,
     popBackStack: () -> Unit
 ) {
     composable(
@@ -29,19 +29,13 @@ fun NavGraphBuilder.timelineDetailGraph(
         val timelineType = TimelineType.valueOf(backStackEntry.arguments?.getString(TimelineDetailRoutes.TIMELINE_TYPE) ?: TimelineType.PINK.name)
         val timelineId = backStackEntry.arguments?.getInt(TimelineDetailRoutes.TIMELINE_ID) ?: 1
 
-        val previousRoute = navController.previousBackStackEntry?.destination?.route ?: "Unknown"
 
-        val previousView = when (previousRoute) {
-            HOME -> "홈"
-            TIMELINE -> "데이트 일정"
-            else -> "Unknown"
-        }
 
         TimelineDetailRoute(
             popBackStack = popBackStack,
             timelineId = timelineId,
             timelineType = timelineType,
-            previousView = previousView
+            previousView = viewPath
         )
     }
 }

--- a/app/src/main/java/org/sopt/dateroad/presentation/util/Constraints.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/util/Constraints.kt
@@ -66,8 +66,6 @@ object TimelineDetailAmplitude {
     const val CLICK_CLOSE_KAKAO = "click_close_kakao"
     const val CLICK_OPEN_KAKAO = "click_open_kakao"
     const val VIEW_PATH = "view_path"
-    const val DATE_COURSE_NUM="date_course_num"
-    const val DATE_TOTAL_DURATION="date_total_duration"
-
-
+    const val DATE_COURSE_NUM = "date_course_num"
+    const val DATE_TOTAL_DURATION = "date_total_duration"
 }

--- a/app/src/main/java/org/sopt/dateroad/presentation/util/Constraints.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/util/Constraints.kt
@@ -49,6 +49,7 @@ object Token {
 object Time {
     const val TIME = " 시간"
 }
+
 object LoadingView {
     const val LOTTIE = "loading.json"
     const val CLIPMIN = 0
@@ -113,6 +114,7 @@ object TimelineAmplitude {
     const val COUNT_DATE_SCHEDULE = "count_date_schedule"
     const val CLICK_ADD_SCHEDULE = "click_add_schedule"
     const val DATE_SCHEDULE_NUM = "date_schedule_num"
+    const val DURATION = "시간"
 }
 
 object UserPropertyAmplitude {

--- a/app/src/main/java/org/sopt/dateroad/presentation/util/Constraints.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/util/Constraints.kt
@@ -59,3 +59,10 @@ object Pattern {
     private const val NICKNAME_PATTERN = "^[ㄱ-ㅎ가-힣a-zA-Z0-9]*$"
     val NICKNAME_REGEX = Regex(NICKNAME_PATTERN)
 }
+
+object TimelineDetailAmplitude {
+    const val VIEW_SCHEDULE_DETAILS = "view_schedule_details"
+    const val CLICK_KAKAO_SHARE = "click_kakao_share"
+    const val CLICK_CLOSE_KAKAO = "click_close_kakao"
+    const val CLICK_OPEN_KAKAO = "click_open_kakao"
+}

--- a/app/src/main/java/org/sopt/dateroad/presentation/util/Constraints.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/util/Constraints.kt
@@ -65,4 +65,9 @@ object TimelineDetailAmplitude {
     const val CLICK_KAKAO_SHARE = "click_kakao_share"
     const val CLICK_CLOSE_KAKAO = "click_close_kakao"
     const val CLICK_OPEN_KAKAO = "click_open_kakao"
+    const val VIEW_PATH = "view_path"
+    const val DATE_COURSE_NUM="date_course_num"
+    const val DATE_TOTAL_DURATION="date_total_duration"
+
+
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #256 

## Work Description ✏️
- 데이트 일정 뷰의 앰플리튜드 트래킹 이벤트 코드를 심었습니다.
- view_schedule_details
- click_kakao_share
- click_close_kakao
- click_open_kakao

## Screenshot 📸

<img width="916" alt="image" src="https://github.com/user-attachments/assets/96b150df-93d0-45b9-ab2f-495821dc2644">

<img width="880" alt="image" src="https://github.com/user-attachments/assets/21c67af2-7a84-437d-aec4-1118668072f7">

유입경로 Home일 때

<img width="933" alt="image" src="https://github.com/user-attachments/assets/5f42aea5-57cc-42d9-aa10-592087d889d0">

유입경로 Timeline일 때

<img width="918" alt="image" src="https://github.com/user-attachments/assets/b60f63f3-5bdd-4b07-93e5-dc84033fa9dc">


## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
뷰 유입 경로는 전체적인 네비게이션을 손봐야 할것 같아서 일단 Test Value 전송하는데 다른 방법 있나요...??
-> 해결 완!