### PR TITLE
[init] Amplitude User Property Setting

### DIFF
--- a/app/src/main/java/org/sopt/dateroad/presentation/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/ui/profile/ProfileScreen.kt
@@ -50,6 +50,8 @@ import org.sopt.dateroad.presentation.ui.component.topbar.DateRoadBasicTopBar
 import org.sopt.dateroad.presentation.ui.component.view.DateRoadErrorView
 import org.sopt.dateroad.presentation.ui.component.view.DateRoadLoadingView
 import org.sopt.dateroad.presentation.util.Pattern.NICKNAME_REGEX
+import org.sopt.dateroad.presentation.util.UserPropertyAmplitude.USER_NAME
+import org.sopt.dateroad.presentation.util.amplitude.AmplitudeUtils
 import org.sopt.dateroad.presentation.util.modifier.noRippleClickable
 import org.sopt.dateroad.presentation.util.view.LoadState
 import org.sopt.dateroad.ui.theme.DateRoadTheme
@@ -122,7 +124,11 @@ fun ProfileRoute(
                 }
 
                 LoadState.Loading -> DateRoadLoadingView()
-                LoadState.Success -> navigationToHome()
+                LoadState.Success -> {
+                    navigationToHome()
+                    AmplitudeUtils.updateStringUserProperty(propertyName = USER_NAME, propertyValue = uiState.signUp.userSignUpInfo.name)
+                }
+
                 LoadState.Error -> DateRoadErrorView()
             }
         }
@@ -155,7 +161,11 @@ fun ProfileRoute(
                 }
 
                 LoadState.Loading -> DateRoadLoadingView()
-                LoadState.Success -> navigationToMyPage()
+                LoadState.Success -> {
+                    navigationToMyPage()
+                    AmplitudeUtils.updateStringUserProperty(propertyName = USER_NAME, propertyValue = uiState.editProfile.name)
+                }
+
                 LoadState.Error -> DateRoadErrorView()
             }
         }

--- a/app/src/main/java/org/sopt/dateroad/presentation/util/Constraints.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/util/Constraints.kt
@@ -114,3 +114,12 @@ object TimelineAmplitude {
     const val CLICK_ADD_SCHEDULE = "click_add_schedule"
     const val DATE_SCHEDULE_NUM = "date_schedule_num"
 }
+
+object UserPropertyAmplitude {
+    const val USER_NAME = "user_name"
+    const val USER_POINT = "user_point"
+    const val USER_FREE_REMAINED = "user_free_remained"
+    const val USER_PURCHASE_COUNT = "user_purchase_count"
+    const val USER_COURSE_COUNT = "user_course_count"
+    const val USER_SCHEDULE_NUM = "user_schedule_num"
+}

--- a/app/src/main/java/org/sopt/dateroad/presentation/util/amplitude/AmplitudeUtils.kt
+++ b/app/src/main/java/org/sopt/dateroad/presentation/util/amplitude/AmplitudeUtils.kt
@@ -3,6 +3,7 @@ package org.sopt.dateroad.presentation.util.amplitude
 import android.content.Context
 import com.amplitude.android.Amplitude
 import com.amplitude.android.Configuration
+import com.amplitude.core.events.Identify
 import org.sopt.dateroad.BuildConfig
 
 object AmplitudeUtils {
@@ -30,5 +31,13 @@ object AmplitudeUtils {
 
     fun trackEventWithProperties(eventName: String, properties: Map<String, Any>) {
         amplitude.track(eventType = eventName, eventProperties = properties)
+    }
+
+    fun updateStringUserProperty(propertyName: String, propertyValue: String) {
+        amplitude.identify(Identify().set(property = propertyName, value = propertyValue))
+    }
+
+    fun updateIntUserProperty(propertyName: String, propertyValue: Int) {
+        amplitude.identify(Identify().set(property = propertyName, value = propertyValue))
     }
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #266 

## Work Description ✏️
- Amplitude User Property Setting 작업을 진행하였습니다.
    - User Property 관련 확장 함수 추가
    - user_name 

## Screenshot 📸
<img width="463" alt="스크린샷 2024-09-18 오후 5 19 20" src="https://github.com/user-attachments/assets/76d28ddd-8c40-42c4-9d36-3631a8f43616">

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
1. User Property Setting
User Property 값에 Int 값이랑 String 관련 값밖에 없어서 두 형식에 관한 updateUserProperty 함수 만들어 두었습니다.
```
fun updateStringUserProperty(propertyName: String, propertyValue: String) {
    amplitude.identify(Identify().set(property = propertyName, value = propertyValue))
}

fun updateIntUserProperty(propertyName: String, propertyValue: Int) {
    amplitude.identify(Identify().set(property = propertyName, value = propertyValue))
}
```
아래와 같이 사용하시면 됩니다.
```
AmplitudeUtils.updateStringUserProperty(propertyName = USER_NAME, propertyValue = uiState.editProfile.name)
```

2. 테스트를 위해 user_name 부분을 연결해두었습니다.
스크린샷 참고하셔서 확인해주시면 됩니다. (event property와 확인하는 방법 다름)