### PR TITLE
[fix] 프로필 수정/등록 이미지 null 처리 로직 수정

### DIFF
--- a/app/src/main/java/org/sopt/teamdateroad/presentation/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/org/sopt/teamdateroad/presentation/ui/profile/ProfileScreen.kt
@@ -76,13 +76,17 @@ fun ProfileRoute(
     val lifecycleOwner = LocalLifecycleOwner.current
 
     val getGalleryLauncher = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
-        viewModel.setEvent(ProfileContract.ProfileEvent.SetSignUpImage(image = uri.toString()))
-        viewModel.setEvent(ProfileContract.ProfileEvent.SetEditProfileImage(image = uri.toString()))
+        uri?.let {
+            viewModel.setEvent(ProfileContract.ProfileEvent.SetSignUpImage(image = it.toString()))
+            viewModel.setEvent(ProfileContract.ProfileEvent.SetEditProfileImage(image = it.toString()))
+        }
     }
 
     val getPhotoPickerLauncher = rememberLauncherForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri: Uri? ->
-        viewModel.setEvent(ProfileContract.ProfileEvent.SetSignUpImage(image = uri.toString()))
-        viewModel.setEvent(ProfileContract.ProfileEvent.SetEditProfileImage(image = uri.toString()))
+        uri?.let {
+            viewModel.setEvent(ProfileContract.ProfileEvent.SetSignUpImage(image = it.toString()))
+            viewModel.setEvent(ProfileContract.ProfileEvent.SetEditProfileImage(image = it.toString()))
+        }
     }
 
     LaunchedEffect(Unit) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 compileSdk = "34"
 minSdk = "28"
 targetSdk = "34"
-versionCode = "1"
+versionCode = "2"
 versionName = "1.0.0"
 jvmTarget = "1.8"
 kotlinCompilerExtensionVersion = "1.5.13"


### PR DESCRIPTION
## Related issue 🛠
- closed #280 

## Work Description ✏️
- 프로필 수정 및 등록 뷰에서 이미지 null 처리 로직을 수정하여 프로필 사진을 선택하지 않고 뒤로가기를 했을 시 서버 에러 로직이 나오는 문제를 해결하였습니다.

## Screenshot 📸
https://github.com/user-attachments/assets/8165b58e-51d7-4c8b-a512-ff6421f5a1c2

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
민석오빠 고생했다능,,